### PR TITLE
Add Atom(RSS) feed.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 remote_theme: pages-themes/hacker@v0.2.0
 plugins:
 - jekyll-remote-theme # add this line to the plugins list if you already have one
+- jekyll-feed # Add ATOM(RSS) feed
 
 # Site basics
 timezone: Europe/Amsterdam


### PR DESCRIPTION
It would be nice to be able to follow this blog through an RSS Feed Reader, so I propose the use of [jekyll-feed](https://github.com/jekyll/jekyll-feed) to automatically generate an Atom(RSS) feed of all present articles.