### PR TITLE
fix: move RSS link from description to dedicated field

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,8 @@ theme: minima
 # Site basic
 timezone: Europe/Amsterdam
 title: "Tom's Blog"
-description: "A blog site covering topics like low level programming, privacy, computers and more; RSS: **https://tomscheers.github.io/feed.xml**."
+description: "A blog site covering topics like low level programming, privacy, computers and more."
+rss: RSS
 url: "https://tomscheers.github.io"
 
 author: "Tom Scheers"


### PR DESCRIPTION
The description field in `_config.yml` is typically used for metadata purposes and SEO. It is not designed to render HTML content directly on your site. For RSS feed link, you can use a dedicated field instead.

<img width="740" height="168" alt="Screenshot 2025-08-12 at 12 41 52" src="https://github.com/user-attachments/assets/b8878512-2e6a-42aa-8c90-8a6fab7198a6" />
